### PR TITLE
feat: enhance schema.org for search accomodations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,7 @@ next-env.d.ts
 
 # Sentry Config File
 .env.sentry-build-plugin
+
+# Generated favicons (copied from DSFR)
+public/favicon.svg
+public/favicon.ico

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "predev": "react-dsfr update-icons",
-    "prebuild": "react-dsfr update-icons",
+    "predev": "react-dsfr update-icons && cp node_modules/@codegouvfr/react-dsfr/dsfr/favicon/favicon.svg public/favicon.svg && cp node_modules/@codegouvfr/react-dsfr/dsfr/favicon/favicon.ico public/favicon.ico",
+    "prebuild": "react-dsfr update-icons && cp node_modules/@codegouvfr/react-dsfr/dsfr/favicon/favicon.svg public/favicon.svg && cp node_modules/@codegouvfr/react-dsfr/dsfr/favicon/favicon.ico public/favicon.ico",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",

--- a/src/app/(public)/trouver-un-logement-etudiant/[[...location]]/get-search-json-ld.ts
+++ b/src/app/(public)/trouver-un-logement-etudiant/[[...location]]/get-search-json-ld.ts
@@ -1,0 +1,40 @@
+import { TTerritory } from '~/schemas/territories'
+import { getCanonicalUrl } from '~/utils/canonical'
+import { type BreadcrumbItem, type FaqItem } from '~/utils/schema'
+
+export function getSearchBreadcrumbItems(territory: TTerritory | undefined, routeCategoryKey: string): BreadcrumbItem[] {
+  return [
+    { name: 'Accueil', item: getCanonicalUrl('/') },
+    { name: 'Trouver un logement étudiant', item: getCanonicalUrl('/trouver-un-logement-etudiant') },
+    ...(territory && routeCategoryKey
+      ? [
+          {
+            name: territory.name,
+            item: getCanonicalUrl(
+              `/trouver-un-logement-etudiant/${routeCategoryKey}/${'slug' in territory ? territory.slug : territory.name}`,
+            ),
+          },
+        ]
+      : []),
+  ]
+}
+
+export function getSearchFaqItems(): FaqItem[] {
+  return [
+    {
+      question: 'Quels types de logements sont accessibles aux étudiants ?',
+      answer:
+        "Plusieurs options s'offrent à vous : Résidences universitaires conventionnées ou à vocation sociale : réservées aux étudiants, elles proposent des loyers encadrés, souvent inférieurs aux prix du marché. L'accès est priorisé pour les étudiants aux revenus modestes (ex. : boursiers du Crous). Résidences services étudiantes : également réservées aux étudiants, mais avec des loyers non encadrés. Location classique : logement indépendant loué auprès d'un particulier ou via une agence. Logement chez l'habitant ou intergénérationnel : chambre louée dans un logement occupé, souvent avec des loyers réduits.",
+    },
+    {
+      question: 'Comment comprendre les typologies de logement (T1, T2, studio, etc.) ?',
+      answer:
+        "Studio : une seule pièce à vivre avec une pièce d'eau (salle de bain/WC). T1 : une pièce à vivre + une cuisine séparée + salle de bain/WC. T2, T3... : chaque chiffre supplémentaire correspond à une pièce en plus (ex. : un T2 comprend un salon et une chambre).",
+    },
+    {
+      question: 'Que signifie "loyer charges comprises" ?',
+      answer:
+        "Si une annonce indique \"cc\" (charges comprises), cela signifie que certaines charges sont incluses dans le loyer, comme l'entretien des parties communes, l'eau froide/chaude ou l'électricité. Vérifiez toujours précisément ce que couvrent les charges avant de signer.",
+    },
+  ]
+}

--- a/src/app/(public)/trouver-un-logement-etudiant/[[...location]]/page.tsx
+++ b/src/app/(public)/trouver-un-logement-etudiant/[[...location]]/page.tsx
@@ -10,8 +10,11 @@ import FindStudentAccommodationQA from '~/components/find-student-accomodation/q
 import { FindStudentAccomodationResultsSections } from '~/components/find-student-accomodation/results/find-student-accomodation-results-sections'
 import { FindStudentAccomodationSortView } from '~/components/find-student-accomodation/sort-view/find-student-accomodation-sort-view'
 import { SearchParamsSync } from '~/components/search-params-sync'
+import { JsonLd } from '~/components/seo/json-ld'
 import { getCanonicalUrl } from '~/utils/canonical'
 import { formatCityWithA } from '~/utils/french-contraction'
+import { buildBreadcrumbSchema, buildFaqSchema } from '~/utils/schema'
+import { getSearchBreadcrumbItems, getSearchFaqItems } from './get-search-json-ld'
 import { getStudentAccommodationPageContext } from './get-student-accommodation-page-context'
 
 export async function generateMetadata({
@@ -68,8 +71,12 @@ export default async function FindStudentAccommodationPage({
   const { dehydratedState, user, territory, isAcademy, serverBbox, serverAcademie, routeCategoryKey } =
     await getStudentAccommodationPageContext(awaitedParams, awaitedSearchParams)
 
+  const breadcrumbItems = getSearchBreadcrumbItems(territory, routeCategoryKey)
+  const faqItems = getSearchFaqItems()
+
   return (
     <HydrationBoundary state={dehydratedState}>
+      <JsonLd data={[buildBreadcrumbSchema(breadcrumbItems), buildFaqSchema(faqItems)]} />
       <SearchParamsSync bbox={serverBbox} academie={serverAcademie} />
       <div className="fr-container">
         <FindStudentAccommodationTitle location={territory?.name} />

--- a/src/app/(public)/trouver-un-logement-etudiant/ville/[location]/[slug]/get-accommodation-json-ld.ts
+++ b/src/app/(public)/trouver-un-logement-etudiant/ville/[location]/[slug]/get-accommodation-json-ld.ts
@@ -1,0 +1,49 @@
+import { getCanonicalUrl } from '~/utils/canonical'
+import { formatCityWithA } from '~/utils/french-contraction'
+import { type BreadcrumbItem, type LodgingData } from '~/utils/schema'
+
+type AccommodationJsonLdParams = {
+  name: string
+  address: string
+  city: string
+  postalCode: string
+  latitude: number
+  longitude: number
+  imagesUrls: string[] | null
+  priceMin: number | null
+  priceMax: number | null
+  description: string | null
+  slug: string
+}
+
+export function getAccommodationBreadcrumbItems(name: string, city: string, slug: string): BreadcrumbItem[] {
+  const cityFormatted = formatCityWithA(city)
+  const accommodationUrl = getCanonicalUrl(`/trouver-un-logement-etudiant/ville/${encodeURIComponent(city)}/${slug}`)
+
+  return [
+    { name: 'Accueil', item: getCanonicalUrl('/') },
+    {
+      name: `Trouver un logement étudiant ${cityFormatted}`,
+      item: getCanonicalUrl(`/trouver-un-logement-etudiant/ville/${encodeURIComponent(city)}`),
+    },
+    { name, item: accommodationUrl },
+  ]
+}
+
+export function getAccommodationLodgingData(params: AccommodationJsonLdParams): LodgingData {
+  const accommodationUrl = getCanonicalUrl(`/trouver-un-logement-etudiant/ville/${encodeURIComponent(params.city)}/${params.slug}`)
+
+  return {
+    name: params.name,
+    address: params.address,
+    city: params.city,
+    postalCode: params.postalCode,
+    latitude: params.latitude,
+    longitude: params.longitude,
+    images: params.imagesUrls ?? [],
+    priceMin: params.priceMin,
+    priceMax: params.priceMax,
+    description: params.description,
+    url: accommodationUrl,
+  }
+}

--- a/src/app/(public)/trouver-un-logement-etudiant/ville/[location]/[slug]/page.tsx
+++ b/src/app/(public)/trouver-un-logement-etudiant/ville/[location]/[slug]/page.tsx
@@ -19,10 +19,13 @@ import { AccommodationImages } from '~/components/accommodation/accommodation-im
 import { NearbyAccommodations } from '~/components/accommodation/nearby-accommodations'
 import { SaveAccommodationFavoriteButton } from '~/components/favorites/save-accommodation-favorite-button'
 import { OwnerDetails } from '~/components/find-student-accomodation/owner-details/owner-details'
+import { JsonLd } from '~/components/seo/json-ld'
 import { getAvailableApartmentTypes } from '~/enums/apartment-type'
 import { EResidenceType, RESIDENCE_TYPE_LABELS } from '~/enums/residence-type'
 import { getCanonicalUrl } from '~/utils/canonical'
 import { formatCityWithA } from '~/utils/french-contraction'
+import { buildBreadcrumbSchema, buildLodgingSchema } from '~/utils/schema'
+import { getAccommodationBreadcrumbItems, getAccommodationLodgingData } from './get-accommodation-json-ld'
 import { getAccommodationPageContext } from './get-accommodation-page-context'
 import styles from './logement.module.css'
 
@@ -84,8 +87,24 @@ export default async function AccommodationPage({ params }: { params: Promise<{ 
     accommodation.residence_type === EResidenceType.SOCIALE_JEUNES_ACTIFS ||
     accommodation.residence_type === EResidenceType.JEUNES_TRAVAILLEURS
 
+  const breadcrumbItems = getAccommodationBreadcrumbItems(name, city, slug)
+  const lodgingData = getAccommodationLodgingData({
+    name,
+    address,
+    city,
+    postalCode: postal_code,
+    latitude,
+    longitude,
+    imagesUrls: images_urls,
+    priceMin: accommodation.price_min,
+    priceMax: accommodation.price_max,
+    description: description ?? null,
+    slug,
+  })
+
   return (
     <HydrationBoundary state={dehydratedState}>
+      <JsonLd data={[buildBreadcrumbSchema(breadcrumbItems), buildLodgingSchema(lodgingData)]} />
       <div className="fr-container">
         <Breadcrumb
           currentPageLabel={breadCrumbTitle}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,10 +7,12 @@ import { Suspense } from 'react'
 import { NextAppDirEmotionCacheProvider } from 'tss-react/next'
 import Matomo from '~/app/matomo'
 import { DossierFacileSuccessToast } from '~/components/dossier-facile/dossier-facile-success-toast'
+import { JsonLd } from '~/components/seo/json-ld'
 import { Signout } from '~/components/signout'
 import Toaster from '~/components/ui/toaster'
 import { DsfrHead, getHtmlAttributes } from '~/dsfr/dsfr-head'
 import { DsfrProvider, StartDsfrOnHydration } from '~/dsfr/dsfr-provider'
+import { buildOrganizationSchema, buildWebSiteSchema } from '~/utils/schema'
 
 export const generateMetadata = async () => {
   const t = await getTranslations('metadata')
@@ -39,6 +41,7 @@ export default async function RootLayout({
         <Suspense fallback={null}>
           <Matomo />
         </Suspense>
+        <JsonLd data={[buildOrganizationSchema(), buildWebSiteSchema()]} />
       </head>
       <body>
         <NextAppDirEmotionCacheProvider options={{ key: 'css' }}>

--- a/src/components/seo/json-ld.tsx
+++ b/src/components/seo/json-ld.tsx
@@ -1,0 +1,7 @@
+type JsonLdProps = {
+  data: object | object[]
+}
+
+export function JsonLd({ data }: JsonLdProps) {
+  return <script type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }} />
+}

--- a/src/utils/schema.ts
+++ b/src/utils/schema.ts
@@ -1,0 +1,121 @@
+import { z } from 'zod'
+
+function getBaseUrl() {
+  return z.string().parse(process.env.BASE_URL)
+}
+
+export type BreadcrumbItem = {
+  name: string
+  item?: string
+}
+
+export type FaqItem = {
+  question: string
+  answer: string
+}
+
+export type LodgingData = {
+  name: string
+  address: string
+  city: string
+  postalCode: string
+  latitude: number
+  longitude: number
+  images: string[]
+  priceMin: number | null
+  priceMax: number | null
+  description: string | null
+  url: string
+}
+
+export function buildOrganizationSchema() {
+  const baseUrl = getBaseUrl()
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: 'Mon Logement Étudiant',
+    url: baseUrl,
+    logo: `${baseUrl}/favicon.svg`,
+    sameAs: ['https://beta.gouv.fr/startups/je-deviens-etudiant.html'],
+  }
+}
+
+export function buildWebSiteSchema() {
+  const baseUrl = getBaseUrl()
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'Mon Logement Étudiant',
+    url: baseUrl,
+    description:
+      "Plateforme nationale pour faciliter l'acces au logement des etudiants boursiers. Recherchez parmi les residences conventionnees, simulez vos aides au logement et preparez votre budget.",
+  }
+}
+
+export function buildBreadcrumbSchema(items: BreadcrumbItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      ...(item.item ? { item: item.item } : {}),
+    })),
+  }
+}
+
+export function buildFaqSchema(faqs: FaqItem[]) {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: faqs.map((faq) => ({
+      '@type': 'Question',
+      name: faq.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: faq.answer,
+      },
+    })),
+  }
+}
+
+export function buildLodgingSchema(data: LodgingData) {
+  const schema: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'LodgingBusiness',
+    name: data.name,
+    url: data.url,
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: data.address,
+      addressLocality: data.city,
+      postalCode: data.postalCode,
+      addressCountry: 'FR',
+    },
+    geo: {
+      '@type': 'GeoCoordinates',
+      latitude: data.latitude,
+      longitude: data.longitude,
+    },
+  }
+
+  if (data.images.length > 0) {
+    schema.image = data.images
+  }
+
+  if (data.priceMin !== null) {
+    schema.priceRange =
+      data.priceMax !== null && data.priceMax !== data.priceMin
+        ? `De ${data.priceMin} € à ${data.priceMax} €`
+        : `À partir de ${data.priceMin} €`
+  }
+
+  if (data.description) {
+    schema.description = data.description
+  }
+
+  return schema
+}


### PR DESCRIPTION
Generate Schema.org for:
- website + organization
- Faq and breadcrumb on search pages
- Lodging Data on search pages. 

Add favicon in public folder, auto copied from DSFR packages (DSFR HEAD/nodes modules)